### PR TITLE
do not include message and code on ad errors, and v0.4.0

### DIFF
--- a/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer.xcodeproj/project.pbxproj
+++ b/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKStatsTHEOplayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -379,7 +379,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.4.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKStatsTHEOplayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer/Binding.swift
+++ b/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer/Binding.swift
@@ -46,7 +46,7 @@ internal class Binding: NSObject {
             adProgress = .started
         }
     }
-    
+
     fileprivate var forceSendAdPlaying: Bool = false
 
     init(name: String, software: String, softwareVersion: String?, automaticErrorTracking: Bool) {
@@ -92,13 +92,15 @@ internal class Binding: NSObject {
 
         playerData { (data) in
             event.playerData = data
-            if let error = error {
-                event.playerData!.playerErrorMessage = error
-                event.playerData!.playerErrorCode = errorCode
-            }
             // careful here, we only want to disable MUXSDKErrorEvent
             // ad errors should still be triggered (MUXSDKAdErrorEvent)
+            // and we don't want to set the player data code/message for
+            // ad errors either
             if (type == MUXSDKErrorEvent.self) {
+                if let error = error {
+                    event.playerData!.playerErrorMessage = error
+                    event.playerData!.playerErrorCode = errorCode
+                }
                 if (self.automaticErrorTracking) {
                     MUXSDKCore.dispatchEvent(event, forPlayer: name)
                 }

--- a/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer/Constants.swift
+++ b/MUXSDKStatsTHEOplayer/MUXSDKStatsTHEOplayer/Constants.swift
@@ -10,6 +10,6 @@ import Foundation
 
 internal struct Constants {
     static let pluginName = "ios-theoplayer-mux"
-    static let pluginVersion = "0.1.1"
+    static let pluginVersion = "0.4.0"
     static let software = "THEOplayer"
 }

--- a/Mux-Stats-THEOplayer.podspec
+++ b/Mux-Stats-THEOplayer.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Mux-Stats-THEOplayer'
 
-  s.version          = '0.3.0'
+  s.version          = '0.4.0'
   s.source           = { :git => 'https://github.com/muxinc/mux-stats-sdk-theoplayer-ios.git',
                          :tag => "v#{s.version}" }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then run `pod install`.
 * Place `THEOplayerSDK.framework` (>= 2.76.0) in the root folder
 
 ## How to release
-* Bump versions in Mux-Stats-THEOplayer.podspec and Marketing Version in XCode Build Settings
+* Bump versions in Mux-Stats-THEOplayer.podspec, Constants.swift, and Marketing Version in XCode Build Settings
 * Execute `update-release-frameworks.sh` to make a full build
 * Github - Create a PR to check in all changed files.
 * If approved, `git tag [YOUR NEW VERSION]` and `git push --tags`


### PR DESCRIPTION
Previously, we were setting player_error_code and player_error_message to the values passed from an AdError event, which makes the view get marked with a fatal error. We need to not do that, for now.