### PR TITLE
Use THEOplayerSDK-basic (2.92.0) pod

### DIFF
--- a/MUXSDKStatsTHEOplayer/Podfile
+++ b/MUXSDKStatsTHEOplayer/Podfile
@@ -1,5 +1,6 @@
 target 'MUXSDKStatsTHEOplayer' do
-  platform :ios, '9.0'
+  platform :ios, '11.0'
 
   pod 'Mux-Stats-Core', '~>2.0'
+  pod 'THEOplayerSDK-basic', '~> 2.89'
 end

--- a/MUXSDKStatsTHEOplayer/Podfile.lock
+++ b/MUXSDKStatsTHEOplayer/Podfile.lock
@@ -1,16 +1,20 @@
 PODS:
   - Mux-Stats-Core (2.3.0)
+  - THEOplayerSDK-basic (2.92.0)
 
 DEPENDENCIES:
   - Mux-Stats-Core (~> 2.0)
+  - THEOplayerSDK-basic (~> 2.89)
 
 SPEC REPOS:
   trunk:
     - Mux-Stats-Core
+    - THEOplayerSDK-basic
 
 SPEC CHECKSUMS:
   Mux-Stats-Core: 636c325a6e2cc54fad54db0918f3da674eef694a
+  THEOplayerSDK-basic: 9d0faf5a62adf3ad8cb91c7542b995edf7b5e0c5
 
-PODFILE CHECKSUM: 55c6397a1087611840a7ad301787e0c3ae31cf85
+PODFILE CHECKSUM: 7ec06330f19a0f6f996229afc27a8abcaf4affd8
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/apps/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/apps/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -9,27 +9,11 @@
 /* Begin PBXBuildFile section */
 		2B37659122E5114D009F4891 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B37659022E5114D009F4891 /* ViewController.swift */; };
 		2B37659322E5117F009F4891 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B37659222E5117F009F4891 /* AppDelegate.swift */; };
-		2B37659E22E5144F009F4891 /* THEOplayerSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B37659922E5143C009F4891 /* THEOplayerSDK.framework */; };
-		2B37659F22E5144F009F4891 /* THEOplayerSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2B37659922E5143C009F4891 /* THEOplayerSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57BB5DEF8A0DBE968C732E38 /* Pods_DemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 654D67DFE51D0F88CF3F7691 /* Pods_DemoApp.framework */; };
 		F444D4461DDB8EBF00FE804F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F444D4441DDB8EBF00FE804F /* Main.storyboard */; };
 		F444D4481DDB8EBF00FE804F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F444D4471DDB8EBF00FE804F /* Assets.xcassets */; };
 		F444D44B1DDB8EBF00FE804F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F444D4491DDB8EBF00FE804F /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		2B3765A022E5144F009F4891 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				2B37659F22E5144F009F4891 /* THEOplayerSDK.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		2B37659022E5114D009F4891 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -50,7 +34,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2B37659E22E5144F009F4891 /* THEOplayerSDK.framework in Frameworks */,
 				57BB5DEF8A0DBE968C732E38 /* Pods_DemoApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -118,7 +101,6 @@
 				F444D4341DDB8EBF00FE804F /* Sources */,
 				F444D4351DDB8EBF00FE804F /* Frameworks */,
 				F444D4361DDB8EBF00FE804F /* Resources */,
-				2B3765A022E5144F009F4891 /* Embed Frameworks */,
 				EFF4EB8B5B695B5EE91803A2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
@@ -211,11 +193,13 @@
 				"${PODS_ROOT}/Target Support Files/Pods-DemoApp/Pods-DemoApp-frameworks.sh",
 				"${PODS_ROOT}/Mux-Stats-Core/Frameworks/iOS/fat/MuxCore.framework",
 				"${PODS_ROOT}/../../../Frameworks/iOS/fat/MUXSDKStatsTHEOplayer.framework",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/THEOplayerSDK-basic/THEOplayerSDK.framework/THEOplayerSDK",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MuxCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MUXSDKStatsTHEOplayer.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/THEOplayerSDK.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/apps/DemoApp/DemoApp/ViewController.swift
+++ b/apps/DemoApp/DemoApp/ViewController.swift
@@ -17,7 +17,8 @@ class ViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.player = THEOplayer(configuration: THEOplayerConfiguration(chromeless: false))
+        let playerConfig = THEOplayerConfiguration(chromeless: false, pip: PiPConfiguration(), license: "YOUR_LICENSE_KEY_HERE")
+        self.player = THEOplayer(configuration: playerConfig)
         self.player.frame = view.bounds
         self.player.addAsSubview(of: view)
 
@@ -31,14 +32,14 @@ class ViewController: UIViewController {
         self.player.source = source
         
         // TODO: Add your property key!
-        let playerData = MUXSDKCustomerPlayerData(environmentKey: "YOUR_ENV_KEY")!
+        let playerData = MUXSDKCustomerPlayerData(environmentKey: "YOUR_ENV_KEY_HERE")!
 
         let videoData = MUXSDKCustomerVideoData()
         videoData.videoTitle = "Big Buck Bunny"
         videoData.videoId = "bigbuckbunny"
         videoData.videoSeries = "animation"
 
-        MUXSDKStatsTHEOplayer.monitorTHEOplayer(self.player, name: playerName, playerData: playerData, videoData: videoData, softwareVersion: "1.1.1")
+        MUXSDKStatsTHEOplayer.monitorTHEOplayer(self.player, name: playerName, playerData: playerData, videoData: videoData, softwareVersion: nil)
         self.player.play()
 
         // Example of changing the video after 60 seconds

--- a/apps/DemoApp/Podfile
+++ b/apps/DemoApp/Podfile
@@ -3,5 +3,6 @@ platform :ios, '11.0'
 target 'DemoApp' do
   use_frameworks!
   pod 'Mux-Stats-THEOplayer', :path => '../..'
+  pod 'THEOplayerSDK-basic', '~> 2.89'
   #pod 'Mux-Stats-THEOplayer', '~> 0.4'
 end

--- a/apps/DemoApp/Podfile.lock
+++ b/apps/DemoApp/Podfile.lock
@@ -2,13 +2,16 @@ PODS:
   - Mux-Stats-Core (2.4.1)
   - Mux-Stats-THEOplayer (0.4.1):
     - Mux-Stats-Core (~> 2.3)
+  - THEOplayerSDK-basic (2.92.0)
 
 DEPENDENCIES:
   - Mux-Stats-THEOplayer (from `../..`)
+  - THEOplayerSDK-basic (~> 2.89)
 
 SPEC REPOS:
   trunk:
     - Mux-Stats-Core
+    - THEOplayerSDK-basic
 
 EXTERNAL SOURCES:
   Mux-Stats-THEOplayer:
@@ -17,7 +20,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Mux-Stats-Core: 0974bcd43bcf16d7ba07518f07001ba5c33749db
   Mux-Stats-THEOplayer: 50a53a72dbf7adfdbbc3fa34f8cc45832141be3e
+  THEOplayerSDK-basic: 9d0faf5a62adf3ad8cb91c7542b995edf7b5e0c5
 
-PODFILE CHECKSUM: 809132d7eb84f2e96f0bc77737462559b912b259
+PODFILE CHECKSUM: 9420039bc6b543e29e61c91fd64f219f262e5e31
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
## Shortcut
https://app.shortcut.com/mux/story/15933/update-theoplayer-ios-sdk-to-obtain-theoplayer-dependency-from-cocoapods-instead-of-linking-to-the-framework-directly

## Overview
We can now use the THEOplayerSDK-basic pod instead of having to link to the framework directly. https://github.com/THEOplayer/theoplayer-sdk-ios#usage

View: https://dashboard.mux.com/organizations/i4rhki/environments/av8gn4/views/lj4nDgBuoy1k3wt1y0c6zksZNdFRaleKA7lZ