### PR TITLE
Update THEOplayer to 9.0.0 and use the new THEOplayer repository

### DIFF
--- a/Mux-Stats-THEOplayer.podspec
+++ b/Mux-Stats-THEOplayer.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.source_files     = 'Sources/**/*.swift'
 
   s.dependency 'Mux-Stats-Core', '~>4.7.1'
-  s.dependency 'THEOplayerSDK-core', '~>8.0'
+  s.dependency 'THEOplayerSDK-core', '~>9.0'
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,12 +10,12 @@
       }
     },
     {
-      "identity" : "theoplayer-sdk-ios",
+      "identity" : "theoplayer-sdk-apple",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/THEOplayer/theoplayer-sdk-ios.git",
+      "location" : "https://github.com/THEOplayer/theoplayer-sdk-apple.git",
       "state" : {
-        "revision" : "5d7dcaada88633aa8859923eba272f88852b0db6",
-        "version" : "7.8.0"
+        "revision" : "585d6d89db438bf516a4d0bebf5b7b1bf9aefcbe",
+        "version" : "9.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Mux-Stats-THEOplayer",
     platforms: [
-        .iOS(.v12),
-        .tvOS(.v12)
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(
@@ -20,8 +20,8 @@ let package = Package(
             exact: "4.7.1"
         ),
         .package(
-            url: "https://github.com/THEOplayer/theoplayer-sdk-ios.git",
-            .upToNextMajor(from: "8.0.0")
+            url: "https://github.com/THEOplayer/theoplayer-sdk-apple.git",
+            .upToNextMajor(from: "9.0.0")
         )
     ],
     targets: [
@@ -34,7 +34,7 @@ let package = Package(
                 ),
                 .product(
                     name: "THEOplayerSDK",
-                    package: "theoplayer-sdk-ios"
+                    package: "theoplayer-sdk-apple"
                 ),
             ]
         ),
@@ -48,7 +48,7 @@ let package = Package(
                 ),
                 .product(
                     name: "THEOplayerSDK",
-                    package: "theoplayer-sdk-ios"
+                    package: "theoplayer-sdk-apple"
                 ),
             ]
         ),

--- a/Sources/MuxStatsTHEOplayer/Binding.swift
+++ b/Sources/MuxStatsTHEOplayer/Binding.swift
@@ -215,7 +215,7 @@ fileprivate extension Binding {
             let source = evt.source?.sources.first
             if (source != nil) {
                 let data = MUXSDKVideoData()
-                data.videoSourceUrl = source?.src.absoluteString
+                data.videoSourceUrl = source?.src
                 let event = MUXSDKDataEvent()
                 event.videoData = data
                 MUXSDKCore.dispatchEvent(event, forPlayer: self.name)
@@ -292,7 +292,7 @@ fileprivate extension Binding {
             self.dispatchEvent(MUXSDKTimeUpdateEvent.self, checkVideoData: true)
         }
 
-        let containsAdsIntegration = player.getAllIntegrations().contains { $0.type == .ADS }
+        let containsAdsIntegration = player.getAllIntegrations().contains { $0.isAdIntegration }
 
         if containsAdsIntegration {
             adBreakBeginListener = player.ads.addEventListener(type: AdsEventTypes.AD_BREAK_BEGIN) { (_: AdBreakBeginEvent) in
@@ -396,5 +396,11 @@ fileprivate extension Ad {
         view.viewPrerollAdId = id
         view.viewPrerollCreativeId = id
         return view
+    }
+}
+
+private extension Integration {
+    var isAdIntegration: Bool {
+        return [.GOOGLE_DAI, .GOOGLE_IMA, .THEO_ADS].contains(kind)
     }
 }


### PR DESCRIPTION
This PR updates the used git repository from THEOplayer as it has been changed starting from 8.3.0 and starts using THEOplayer 9.0.0.