### PR TITLE
chore: update THEOplayer and MuxStatsCore

### DIFF
--- a/Mux-Stats-THEOplayer.podspec
+++ b/Mux-Stats-THEOplayer.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.license          = 'Apache 2.0'
   s.author           = { 'Mux' => 'ios-sdk@mux.com' }
 
-  s.ios.deployment_target   = '13.0'
+  s.ios.deployment_target   = '15.0'
   s.swift_versions   = ['5.0']
 
   s.source_files     = 'Sources/**/*.swift'

--- a/Mux-Stats-THEOplayer.podspec
+++ b/Mux-Stats-THEOplayer.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |s|
   s.source_files     = 'Sources/**/*.swift'
 
   s.dependency 'Mux-Stats-Core', '~>5.4.0'
-  s.dependency 'THEOplayerSDK-core', '~>10.0'
+  s.dependency 'THEOplayerSDK-core', '~>11.0'
 
 end

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/muxinc/stats-sdk-objc.git",
       "state" : {
-        "revision" : "36fc59da21644e328c143a05f50510f575feec45",
-        "version" : "5.7.1"
+        "revision" : "720206a95a1206cf7ec0d2e4cb12d4989c9fa740",
+        "version" : "5.13.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/THEOplayer/theoplayer-sdk-apple.git",
       "state" : {
-        "revision" : "e9a587d2a499d225efce843a76c36770343cfbbc",
-        "version" : "10.7.0"
+        "revision" : "565e587837e70098c27afb123e24f5833eaf5c42",
+        "version" : "11.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Mux-Stats-THEOplayer",
     platforms: [
-        .iOS(.v13),
-        .tvOS(.v13)
+        .iOS(.v15),
+        .tvOS(.v15)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/THEOplayer/theoplayer-sdk-apple.git",
-            .upToNextMajor(from: "10.0.0")
+            .upToNextMajor(from: "11.0.0")
         )
     ],
     targets: [


### PR DESCRIPTION
This PR updates THEOplayer dependency to start using 11.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major THEOplayer and minimum OS bumps can break existing integrators on iOS 13–14 or if THEOplayer 11 introduces API changes not reflected in this repo’s Swift code.
> 
> **Overview**
> Raises the **minimum platform** for CocoaPods and SwiftPM from **iOS/tvOS 13** to **15**, so apps still targeting 13–14 can no longer depend on this release without upgrading.
> 
> **THEOplayer** is bumped to a **11.x** line (`THEOplayerSDK-core` `~>11.0` / SPM `11.0.0+`); `Package.resolved` pins **11.5.0** (was 10.7.0). Resolved **Mux stats-sdk-objc** moves to **5.13.0** (was 5.7.1) while the declared `Mux-Stats-Core` range stays `~>5.4.0`. No changes under `Sources/` in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5079473b5082e59cb03d4b992aaba9f75eb196c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->