### PR TITLE
Fix crash when currentTime is not finite

### DIFF
--- a/Sources/MuxStatsTHEOplayer/Binding.swift
+++ b/Sources/MuxStatsTHEOplayer/Binding.swift
@@ -140,8 +140,9 @@ fileprivate extension Binding {
         data.playerHeight = player.frame.size.height * UIScreen.main.nativeScale as NSNumber
         data.playerIsFullscreen = player.frame.equalTo(UIScreen.main.bounds) ? "true" : "false"
         data.playerIsPaused = NSNumber(booleanLiteral: player.paused)
-        if player.currentTime.isFinite {
-            data.playerPlayheadTime = NSNumber(value: (Int64)(player.currentTime * 1000))
+        let currentTime = player.currentTime
+        if currentTime.isFinite {
+            data.playerPlayheadTime = currentTime * 1000 as NSNumber
         }
         return data
     }

--- a/Sources/MuxStatsTHEOplayer/Binding.swift
+++ b/Sources/MuxStatsTHEOplayer/Binding.swift
@@ -140,7 +140,9 @@ fileprivate extension Binding {
         data.playerHeight = player.frame.size.height * UIScreen.main.nativeScale as NSNumber
         data.playerIsFullscreen = player.frame.equalTo(UIScreen.main.bounds) ? "true" : "false"
         data.playerIsPaused = NSNumber(booleanLiteral: player.paused)
-        data.playerPlayheadTime = NSNumber(value: (Int64)(player.currentTime * 1000))
+        if player.currentTime.isFinite {
+            data.playerPlayheadTime = NSNumber(value: (Int64)(player.currentTime * 1000))
+        }
         return data
     }
 


### PR DESCRIPTION
This should fix https://github.com/muxinc/mux-stats-sdk-theoplayer-ios/issues/39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in analytics payload construction; no auth, playback, or data-persistence impact.
> 
> **Overview**
> Fixes a crash when building Mux player data if THEOplayer reports a non-finite `currentTime` (e.g. NaN or infinity).
> 
> In `playerData()`, **`playerPlayheadTime` is only set when `currentTime.isFinite`**, instead of always casting `currentTime * 1000` to `Int64` for `NSNumber`. When the value is not finite, playhead time is omitted from the payload rather than forcing an invalid conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52bc80f789980427dffaecd5de99cb7d21f5a01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->