### PR TITLE
Add set-version.sh release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Then run `pod install`.
 
 * Checkout and push a release branch named: `releases/vX.Y.Z` where X, Y, Z are the major, minor, and patch versions of the release
 * Github - open pull requests with release branch as destination for your changes
-* Update version in Mux-Stats-THEOplayer.podspec on release branch
-* Update version in `Constants.swift` on release branch
-* Update version in the Examples and in this README
+* Set the new version by running `scripts/set-version.sh X.Y.Z`. This updates `Mux-Stats-THEOplayer.podspec`, `Constants.swift`, and this README.
 * Github - open a pull request to merge release branch to `master`
 * If approved, merge release branch using squash merging 
 * Add `git tag [YOUR NEW VERSION]` and `git push --tags`

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# set-version.sh — Set a new release version across the codebase.
+#
+# Usage:
+#   scripts/set-version.sh X.Y.Z
+#
+set -euo pipefail
+IFS=$'\n\t'
+
+# --- Locate the repository root relative to this script -----------------------
+# Resolve regardless of the caller's current working directory.
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+readonly PODSPEC="${REPO_ROOT}/Mux-Stats-THEOplayer.podspec"
+readonly CONSTANTS="${REPO_ROOT}/Sources/MuxStatsTHEOplayer/Constants.swift"
+readonly README="${REPO_ROOT}/README.md"
+
+# Temp file used by update_file; cleaned up on exit if a run is interrupted.
+TMP_FILE=""
+cleanup() {
+  if [[ -n "$TMP_FILE" ]]; then
+    rm -f "$TMP_FILE"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat >&2 <<EOF
+Usage: ${0##*/} <version>
+
+Set a new release version (X.Y.Z) across the podspec, Constants.swift and README.
+
+Arguments:
+  version   New semantic version, e.g. 0.15.0 (a leading "v" is accepted).
+
+Example:
+  ${0##*/} 0.15.0
+EOF
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+# update_file <file> <locator-regex> <sed-substitution> <description>
+update_file() {
+  local file="$1" locator="$2" substitution="$3" description="$4"
+
+  [[ -f "$file" ]] || die "file not found: ${file}"
+  grep -Eq "$locator" "$file" \
+    || die "could not find ${description} in ${file} (pattern: ${locator})"
+
+  TMP_FILE="$(mktemp)"
+  sed -E "$substitution" "$file" >"$TMP_FILE"
+  cat "$TMP_FILE" >"$file"
+  rm -f "$TMP_FILE"
+  TMP_FILE=""
+
+  echo "  ✓ ${description}"
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+  esac
+
+  [[ $# -eq 1 ]] || { usage; die "exactly one argument (the new version) is required"; }
+
+  # Accept an optional leading "v", then validate strict semver X.Y.Z as the
+  # README specifies ("X, Y, Z are the major, minor, and patch versions").
+  local version="${1#v}"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "invalid version '${1}'; expected X.Y.Z (e.g. 0.15.0)"
+
+  # major.minor, used for the CocoaPods '~> X.Y' constraint in the README.
+  local major_minor="${version%.*}"
+
+  echo "Setting version to ${version} (CocoaPods constraint '~> ${major_minor}')"
+
+  # podspec: s.version          = 'X.Y.Z'
+  update_file "$PODSPEC" \
+    "^[[:space:]]*s\.version[[:space:]]*=" \
+    "s/^([[:space:]]*s\.version[[:space:]]*=[[:space:]]*')[^']*'/\1${version}'/" \
+    "podspec s.version"
+
+  # Constants.swift: static let pluginVersion = "X.Y.Z"
+  update_file "$CONSTANTS" \
+    "static let pluginVersion[[:space:]]*=" \
+    "s/(static let pluginVersion[[:space:]]*=[[:space:]]*\")[^\"]*\"/\1${version}\"/" \
+    "Constants.swift pluginVersion"
+
+  # README Swift Package Manager snippet: .upToNextMajor(from: "X.Y.Z")
+  update_file "$README" \
+    "\.upToNextMajor\(from:[[:space:]]*\"" \
+    "s/(\.upToNextMajor\(from:[[:space:]]*\")[^\"]*\"/\1${version}\"/" \
+    "README Swift Package Manager version"
+
+  # README CocoaPods snippet: pod 'Mux-Stats-THEOplayer', '~> X.Y'
+  update_file "$README" \
+    "pod 'Mux-Stats-THEOplayer',[[:space:]]*'~>" \
+    "s/(pod 'Mux-Stats-THEOplayer',[[:space:]]*'~>[[:space:]]*)[^']*'/\1${major_minor}'/" \
+    "README CocoaPods version"
+
+  echo
+  echo "Done. Review the changes with 'git diff' before committing."
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds `scripts/set-version.sh`, a single command that sets a new release version across every file that hardcodes it, and updates the README's **How to release** section to invoke it instead of listing the edits by hand.

Given a version `X.Y.Z`, the script updates:
- `Mux-Stats-THEOplayer.podspec` → `s.version`
- `Sources/MuxStatsTHEOplayer/Constants.swift` → `pluginVersion`
- `README.md` → the Swift Package Manager (`.upToNextMajor(from: …)`) and CocoaPods (`~> X.Y`) install snippets

```
scripts/set-version.sh 0.15.0
```

## Why

The release process previously asked the releaser to manually bump the version in several places, which is easy to get out of sync (e.g. the README install snippets already lagged the podspec/Constants version). One script keeps them consistent.

## Notes for reviewers

- **Examples are intentionally not touched.** Both example apps consume this package via local references (`:path => '../..'` and a local Swift package reference), so they carry no published-version string to bump. The old "update version in the Examples" instruction was removed from the README as it was not actionable.
- **Strict bash practices:** `set -euo pipefail`, `IFS=$'\n\t'`, semver validation of the argument (a leading `v` is accepted), repo-root resolved relative to the script so it runs from any directory.
- **Fails loudly:** each edit first confirms its target line exists and exits non-zero with a clear message if not, rather than silently making no change.
- **Preserves file permissions:** writes back via `cat > file` rather than `mv`, so existing modes are unchanged. The operation is idempotent.

### Testing

Verified: syntax check; argument validation (missing/invalid/too-many args, `--help`); a full run from another directory with a `v`-prefixed version applying all four edits correctly; file modes preserved; idempotent re-run; and the target-not-found path exiting non-zero. No test artifacts remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release tooling and documentation only; no runtime SDK, auth, or data-path changes.
> 
> **Overview**
> Adds **`scripts/set-version.sh`** so a release bump is one command instead of hand-editing several files. Given **`X.Y.Z`** (optional leading **`v`**), it updates **`Mux-Stats-THEOplayer.podspec`** **`s.version`**, **`Constants.swift`** **`pluginVersion`**, and the README’s SPM **`.upToNextMajor(from:)`** and CocoaPods **`~> X.Y`** snippets, with semver validation, grep-before-sed checks, and repo-root resolution from any cwd.
> 
> The README **How to release** section now points at that script and drops the old per-file checklist and the non-actionable “update version in the Examples” step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdb61437f970a8dbb1aadef104dc496331e4dccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->